### PR TITLE
Speed up code by avoiding odometryLock using cached robot pose from SwerveDrive's Field2d

### DIFF
--- a/src/main/java/frc/robot/commands/AlignToAmp.java
+++ b/src/main/java/frc/robot/commands/AlignToAmp.java
@@ -117,7 +117,7 @@ public class AlignToAmp extends Command {
   }
 
   private Pose2d getPose() {
-    return new Pose2d(RobotContainer.drive.drive.getPose().getTranslation(), new Rotation2d())
+    return new Pose2d(RobotContainer.drive.getPoseEfficiently().getTranslation(), new Rotation2d())
       // TODO: measure actual distance
       .plus(new Transform2d(0, 0.45, new Rotation2d())); // offset distance from center of robot to front bumper
   }

--- a/src/main/java/frc/robot/commands/AprilTagTrackDrive.java
+++ b/src/main/java/frc/robot/commands/AprilTagTrackDrive.java
@@ -95,7 +95,7 @@ public class AprilTagTrackDrive extends Command {
   private Rotation2d getHeadingToTag() {
     // strip the rotation component of the apriltag pose so coordinates align with the field
     Pose2d aprilTagPose = new Pose2d(AprilTag.getPose2d(trackedAprilTagID).getTranslation(), new Rotation2d());
-    Transform2d relativePose = RobotContainer.drive.drive.getPose().minus(aprilTagPose);
+    Transform2d relativePose = RobotContainer.drive.getPoseEfficiently().minus(aprilTagPose);
     return Rotation2d.fromRadians(Math.atan2(relativePose.getY(), relativePose.getX()));
   }
 

--- a/src/main/java/frc/robot/commands/AutoSetShooter.java
+++ b/src/main/java/frc/robot/commands/AutoSetShooter.java
@@ -57,7 +57,7 @@ public class AutoSetShooter extends Command {
 
   @Override
   public void execute() {
-    final Pose2d robotPose = RobotContainer.drive.drive.getPose();
+    final Pose2d robotPose = RobotContainer.drive.getPoseEfficiently();
     final double distanceToSpeaker = robotPose.getTranslation().getDistance(speakerTranslation);
     final double pivotDistanceToSpeaker = distanceToSpeaker + shooterDistanceFromCenter;
     heightOffset = SmartDashboard.getNumber("Height Offset", heightOffset);

--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -183,7 +183,7 @@ public class Limelight extends SubsystemBase {
    * @return Linear distance between vision and odometry poses.
    */
   public static double getOdometryDifference(Pose2d pose) {
-    var odometryDifference = RobotContainer.drive.drive.getPose().minus(pose);
+    var odometryDifference = RobotContainer.drive.getPoseEfficiently().minus(pose);
     return Math.hypot(odometryDifference.getX(), odometryDifference.getY());
   }
 

--- a/src/main/java/frc/robot/utils/Visualizer.java
+++ b/src/main/java/frc/robot/utils/Visualizer.java
@@ -44,7 +44,7 @@ public class Visualizer {
     
     // --- note
     // game pieces don't move with the robot, must do it manually
-    Pose3d intakePose = new Pose3d(RobotContainer.drive.drive.getPose()).transformBy(intakeTransform);
+    Pose3d intakePose = new Pose3d(RobotContainer.drive.getPoseEfficiently()).transformBy(intakeTransform);
     if (RobotContainer.intake.noteHeld) {
       // put the note into the intake
       notePublisher.set(intakePose.transformBy(new Transform3d(new Translation3d(0.16, 0, 0.08), new Rotation3d(0, 0.48869219, 0))));


### PR DESCRIPTION
* `SwerveDrive::getPose()` waits for `odometryLock` before getting the pose of the robot from `swerveDrivePoseEstimator`, which is required so it doesn't try to get the pose of the robot while it's being updated.
* However, this slows down the robot code since any function calling `getPose()` needs to wait for `odometryLock` (which takes **a while** to be released).
* SwerveDrive has a Field2d object that is updated with the pose of the robot whenever odometry is updated, so its pose can be used instead of the one from `getPose()`. The Field2d has a thread lock similar to `getPose()`, but it is locked for a much smaller amount of time, so the code doesn't spend anywhere near the amount of time waiting for it.
* This PR replaces calls to `getPose()` with a call to `getPoseEfficiently()`, which returns the pose from the Field2d. It significantly increases the speed the code runs at.